### PR TITLE
Allow JSON Schema Generator to accept user defined options.

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -8,7 +8,7 @@ used for generating the schema.
 */
 var utils = require('./utils');
 var crypto = require('crypto');
-
+var options;
 /**
 Abstract Syntax Tree Class
 
@@ -43,7 +43,7 @@ AST.prototype.generateHash = function(value) {
 
 /**
 Checks if the elements in the given node are all
-equal. 
+equal.
 
 @method isAllSimilarObject
 @param {Object} node JSON node to inspect
@@ -78,8 +78,8 @@ and mark as required if the element contains a value.
 AST.prototype.buildPrimitive = function(tree, node) {
   tree.type = utils.getType(node);
   if (tree.type === 'string') {
-    tree.minLength = (node.length > 0) ? 1 : 0;
-  } 
+    tree.minLength = (node.length > 0  && options.required) ? 1 : 0;
+  }
 
   if (node !== null && typeof node !== 'undefined') {
     tree.required = true;
@@ -88,7 +88,7 @@ AST.prototype.buildPrimitive = function(tree, node) {
 
 /**
 Inspect object properties and apply the correct
-type and mark as required if the element has set 
+type and mark as required if the element has set
 properties.
 
 @method buildObject
@@ -109,13 +109,13 @@ AST.prototype.buildObjectTree = function(tree, node) {
     } else {
       tree.children[i] = {};
       this.buildPrimitive(tree.children[i], node[i]);
-    } 
+    }
   }
 };
 
 /**
 Inspect array elements apply the correct
-type and mark as required if the element has 
+type and mark as required if the element has
 set properties.
 
 @method buildObject
@@ -163,13 +163,14 @@ AST.prototype.buildArrayTree = function(tree, node) {
 };
 
 /**
-Initiates generating the AST from the 
+Initiates generating the AST from the
 given JSON document.
 
 @param {Object} json JSON object
 @return void
 */
-AST.prototype.build = function(json) {
+AST.prototype.build = function(json, opts) {
+  options = opts;
   if (json instanceof Array) {
     this.buildArrayTree(this.tree, json);
   } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,20 @@ var Compiler = require('./compiler');
 var AST = require('./ast.js');
 var utils = require('./utils');
 
-var jsonToSchema = function(json) {
+function hasKey(obj, key) {
+  return obj != null && hasOwnProperty.call(obj, key);
+}
+
+function defaultOptions(options) {
+  options = options ? options : {};
+  return options.required = false;
+}
+
+var jsonToSchema = function(json, options) {
+  var options = (options && hasKey(options, 'required')) ? options : defaultOptions(options);
   var compiler = new Compiler();
   var ast = new AST();
-  ast.build(json);
+  ast.build(json, options);
   compiler.compile(ast.tree);
   return compiler.schema;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,5 +92,7 @@ exports.getType = function(data) {
     return 'string';
   } else if (exports.isNumber(data)) {
     return 'number';
+  } else if(exports.isFunction(data)) {
+    return 'string';
   }
 };


### PR DESCRIPTION
Options to jsonSchemaGenerator are optional.
By default, the required property set to false.

Example:
jsonSchemaGenerator = require('json-schema-generator')
var options = { required: true };
schema = jsonSchemaGenerator(json, options)